### PR TITLE
Sort by created at rather than computed numeric ID

### DIFF
--- a/app/components/quote-list.js
+++ b/app/components/quote-list.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { sort } from '@ember/object/computed';
 
 export default class QuoteListComponent extends Component {
-  sortProperties = Object.freeze(['numericId:desc']);
+  sortProperties = Object.freeze(['createdAt:desc']);
 
   @sort('args.quotes', 'sortProperties')
   sortedQuotes;

--- a/app/models/quote.js
+++ b/app/models/quote.js
@@ -5,10 +5,8 @@ export default class QuoteModel extends Model {
   @attr() text;
   @attr() location;
   @attr() comments;
+  @attr('date') createdAt;
+
   @belongsTo('source') source;
   @belongsTo('idea') idea;
-
-  get numericId() {
-    return Number(this.id);
-  }
 }


### PR DESCRIPTION
Sorting by the computed numeric ID used to work, but after updating to the latest Ember Octane, it doesn't update right away; it's not until you add a _second_ quote that the _first_ gets its `numericId` recomputed. Question out to the Ember core team about it in Discord #st-octane